### PR TITLE
fix(copilot): implement GitHub device flow to fix 404 login error

### DIFF
--- a/src-tauri/src/commands/copilot.rs
+++ b/src-tauri/src/commands/copilot.rs
@@ -1,0 +1,128 @@
+//! GitHub Copilot Device Flow Commands
+//!
+//! Proxies GitHub OAuth device flow requests through Rust/reqwest to avoid
+//! CORS restrictions in the Tauri webview. GitHub's device flow endpoints
+//! do not set CORS headers, so they cannot be called directly from JS.
+
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+const GITHUB_CLIENT_ID: &str = "Iv1.b507a08c87ecfe98";
+const DEVICE_CODE_URL: &str = "https://github.com/login/device/code";
+const TOKEN_URL: &str = "https://github.com/login/oauth/access_token";
+const USER_INFO_URL: &str = "https://api.github.com/user";
+
+// ── Request device code ─────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DeviceCodeResponse {
+    pub device_code: String,
+    pub user_code: String,
+    pub verification_uri: String,
+    pub expires_in: u64,
+    pub interval: u64,
+}
+
+/// Step 1: Request a device code from GitHub.
+#[tauri::command]
+pub async fn github_request_device_code() -> Result<DeviceCodeResponse, String> {
+    let client = Client::new();
+
+    let mut params = HashMap::new();
+    params.insert("client_id", GITHUB_CLIENT_ID);
+    params.insert("scope", "read:user user:email");
+
+    let res = client
+        .post(DEVICE_CODE_URL)
+        .header("Accept", "application/json")
+        .form(&params)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to request device code: {e}"))?;
+
+    if !res.status().is_success() {
+        let status = res.status().as_u16();
+        let body = res.text().await.unwrap_or_default();
+        return Err(format!("GitHub returned {status}: {body}"));
+    }
+
+    res.json::<DeviceCodeResponse>()
+        .await
+        .map_err(|e| format!("Failed to parse device code response: {e}"))
+}
+
+// ── Poll for token ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TokenPollResponse {
+    /// Populated when auth succeeds.
+    pub access_token: Option<String>,
+    pub token_type: Option<String>,
+    pub scope: Option<String>,
+    /// Populated when still waiting or on error.
+    pub error: Option<String>,
+    pub error_description: Option<String>,
+}
+
+/// Step 2: Poll GitHub once for an access token.
+/// Returns the raw response so the frontend can handle all error cases.
+#[tauri::command]
+pub async fn github_poll_token(device_code: String) -> Result<TokenPollResponse, String> {
+    let client = Client::new();
+
+    let mut params = HashMap::new();
+    params.insert("client_id", GITHUB_CLIENT_ID);
+    params.insert(
+        "grant_type",
+        "urn:ietf:params:oauth:grant-type:device_code",
+    );
+    let device_code_ref = device_code.as_str();
+    params.insert("device_code", device_code_ref);
+
+    let res = client
+        .post(TOKEN_URL)
+        .header("Accept", "application/json")
+        .form(&params)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to poll for token: {e}"))?;
+
+    res.json::<TokenPollResponse>()
+        .await
+        .map_err(|e| format!("Failed to parse token response: {e}"))
+}
+
+// ── Fetch user info ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UserInfoResponse {
+    pub login: Option<String>,
+    pub email: Option<String>,
+    pub name: Option<String>,
+}
+
+/// Step 3: Fetch the authenticated user's GitHub profile.
+#[tauri::command]
+pub async fn github_fetch_user_info(access_token: String) -> Result<UserInfoResponse, String> {
+    let client = Client::new();
+
+    let res = client
+        .get(USER_INFO_URL)
+        .header("Authorization", format!("Bearer {access_token}"))
+        .header("Accept", "application/json")
+        .header("User-Agent", "zero-limit")
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch user info: {e}"))?;
+
+    if !res.status().is_success() {
+        let status = res.status().as_u16();
+        let body = res.text().await.unwrap_or_default();
+        return Err(format!("GitHub returned {status}: {body}"));
+    }
+
+    res.json::<UserInfoResponse>()
+        .await
+        .map_err(|e| format!("Failed to parse user info: {e}"))
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6,8 +6,10 @@ mod cli_proxy;
 mod utils;
 mod download;
 mod version;
+mod copilot;
 
 pub use cli_proxy::*;
 pub use utils::*;
 pub use download::*;
 pub use version::*;
+pub use copilot::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -97,6 +97,9 @@ pub fn run() {
             is_cli_proxy_running,
             download_and_extract_proxy,
             check_proxy_version,
+            github_request_device_code,
+            github_poll_token,
+            github_fetch_user_info,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src/services/api/copilot.service.ts
+++ b/src/services/api/copilot.service.ts
@@ -1,0 +1,165 @@
+/**
+ * GitHub Copilot Device Flow Service
+ *
+ * Implements the GitHub OAuth2 device flow entirely in the frontend,
+ * so it works with the base CLIProxyAPI (which lacks /github-auth-url).
+ *
+ * All GitHub API calls are proxied through Tauri Rust commands to avoid
+ * CORS restrictions — GitHub's device flow endpoints do not set CORS headers.
+ *
+ * Flow:
+ *   1. invoke('github_request_device_code')  → get device_code + user_code + verification_uri
+ *   2. Show user_code to user, open verification_uri in browser
+ *   3. Poll invoke('github_poll_token') until authorized
+ *   4. invoke('github_fetch_user_info')  → fetch username / email / name
+ *   5. Build CopilotTokenStorage JSON, upload via POST /auth-files
+ */
+
+import { invoke } from '@tauri-apps/api/core'
+
+const DEFAULT_POLL_INTERVAL_MS = 5000
+const MAX_POLL_DURATION_MS = 15 * 60 * 1000
+
+export interface CopilotDeviceCode {
+  device_code: string
+  user_code: string
+  verification_uri: string
+  expires_in: number
+  interval: number
+}
+
+export interface CopilotTokenData {
+  access_token: string
+  token_type: string
+  scope: string
+}
+
+export interface CopilotUserInfo {
+  login: string
+  email: string | null
+  name: string | null
+}
+
+/** Shape stored as the auth JSON file (mirrors Go CopilotTokenStorage) */
+export interface CopilotTokenStorage {
+  access_token: string
+  token_type: string
+  scope: string
+  username: string
+  email?: string
+  name?: string
+  type: 'github-copilot'
+}
+
+/** Step 1: Request device code via Rust (bypasses CORS) */
+export async function requestDeviceCode(): Promise<CopilotDeviceCode> {
+  return invoke<CopilotDeviceCode>('github_request_device_code')
+}
+
+/**
+ * Step 2+3: Poll GitHub until the user authorizes.
+ * Resolves with the access token on success, rejects on error/timeout.
+ */
+export async function pollForToken(
+  deviceCode: CopilotDeviceCode,
+  signal?: AbortSignal,
+): Promise<CopilotTokenData> {
+  let intervalMs = Math.max(deviceCode.interval * 1000, DEFAULT_POLL_INTERVAL_MS)
+  const deadline = Date.now() + Math.min(deviceCode.expires_in * 1000, MAX_POLL_DURATION_MS)
+
+  while (Date.now() < deadline) {
+    if (signal?.aborted) {
+      throw new Error('Authentication cancelled')
+    }
+
+    await new Promise<void>((resolve) => setTimeout(resolve, intervalMs))
+
+    if (signal?.aborted) {
+      throw new Error('Authentication cancelled')
+    }
+
+    const data = await invoke<{
+      access_token?: string
+      token_type?: string
+      scope?: string
+      error?: string
+      error_description?: string
+    }>('github_poll_token', { deviceCode: deviceCode.device_code })
+
+    if (data.error) {
+      switch (data.error) {
+        case 'authorization_pending':
+          continue
+        case 'slow_down':
+          intervalMs += 5000
+          continue
+        case 'expired_token':
+          throw new Error('Device code expired. Please try again.')
+        case 'access_denied':
+          throw new Error('Access denied by user.')
+        default:
+          throw new Error(data.error_description || data.error || 'Token exchange failed')
+      }
+    }
+
+    if (!data.access_token) {
+      throw new Error('Empty access token received')
+    }
+
+    return {
+      access_token: data.access_token,
+      token_type: data.token_type ?? 'bearer',
+      scope: data.scope ?? '',
+    }
+  }
+
+  throw new Error('Device code expired. Please try again.')
+}
+
+/** Step 4: Fetch GitHub user profile via Rust (bypasses CORS) */
+export async function fetchUserInfo(accessToken: string): Promise<CopilotUserInfo> {
+  const data = await invoke<{ login?: string; email?: string | null; name?: string | null }>(
+    'github_fetch_user_info',
+    { accessToken },
+  )
+  return {
+    login: data.login ?? '',
+    email: data.email ?? null,
+    name: data.name ?? null,
+  }
+}
+
+/** Build the JSON blob that gets uploaded as an auth file */
+export function buildTokenStorage(
+  tokenData: CopilotTokenData,
+  userInfo: CopilotUserInfo,
+): { storage: CopilotTokenStorage; fileName: string } {
+  const username = userInfo.login || 'github-user'
+  const storage: CopilotTokenStorage = {
+    access_token: tokenData.access_token,
+    token_type: tokenData.token_type,
+    scope: tokenData.scope,
+    username,
+    type: 'github-copilot',
+  }
+  if (userInfo.email) storage.email = userInfo.email
+  if (userInfo.name) storage.name = userInfo.name
+
+  const fileName = `github-copilot-${username}.json`
+  return { storage, fileName }
+}
+
+/**
+ * Upload the token storage JSON as a multipart file to the backend /auth-files endpoint.
+ * Uses the existing authFilesApi.upload() so it goes through the same auth/base-URL as everything else.
+ */
+export async function uploadTokenFile(
+  storage: CopilotTokenStorage,
+  fileName: string,
+  uploadFn: (formData: FormData) => Promise<unknown>,
+): Promise<void> {
+  const blob = new Blob([JSON.stringify(storage, null, 2)], { type: 'application/json' })
+  const formData = new FormData()
+  formData.append('file', blob, fileName)
+  await uploadFn(formData)
+}


### PR DESCRIPTION
## Summary

- CLIProxyAPI officially refused to support GitHub Copilot (reason: unofficial API interface, PR #1697 was closed), so we implemented the full authentication flow on the zero-limit frontend without requiring any backend changes
- GitHub device flow endpoints (`github.com/login/device/code`, `github.com/login/oauth/access_token`) do not include CORS headers, causing direct `fetch()` calls from the webview to be blocked by the browser
- Tauri Rust commands proxy these GitHub requests server-side via `reqwest`, bypassing CORS entirely, then upload the obtained token to CLIProxyAPI's existing `/auth-files` endpoint to complete account binding

## Changes

### New Files
- `src-tauri/src/commands/copilot.rs` — Three Rust commands:
  - `github_request_device_code` — Request device code from GitHub
  - `github_poll_token` — Poll for access token (one call per interval)
  - `github_fetch_user_info` — Fetch user profile (login/email/name)
- `src/services/api/copilot.service.ts` — Frontend typed wrappers: device flow orchestration, token storage construction, file upload

### Modified Files
- `src-tauri/src/commands/mod.rs` — Register the copilot module
- `src-tauri/src/lib.rs` — Register three new commands in `invoke_handler`
- `src/features/providers/useProvidersPresenter.ts` — Copilot `startAuth` now calls the new service; `cancelAuth` supports AbortController for proper cleanup

## Background

The base CLIProxyAPI does not expose a `/github-auth-url` endpoint, so calling `oauthApi.startAuth('copilot')` returns 404. Since CLIProxyAPI refused to add Copilot support upstream, this PR brings the entire login flow client-side. Rust's `reqwest` handles the CORS-restricted GitHub endpoints, and the resulting token file is written to CLIProxyAPI via the existing auth-files API, integrating seamlessly with the quota display.

## Testing

- `pnpm build` — TypeScript compilation passes
- `pnpm tauri build` — Executable built successfully
- Verified on real device: device code displayed correctly, browser opened authorization page, account info appeared in Quota view after authorization

### Before modification

<img width="1504" height="1073" alt="aa7f5e1d2feb481914bdf7c8ad56f2ae" src="https://github.com/user-attachments/assets/0536f704-5676-4ec8-839e-324c16f90fee" />

### After modification

<img width="1530" height="1091" alt="f8065f433dc07faf8f0c2a1c1ba3c10c" src="https://github.com/user-attachments/assets/3162aaff-49e5-402f-8710-1a89f6bb428e" />
<img width="1534" height="1092" alt="c9ad7360f72b250c4e5ebe3b3118631d" src="https://github.com/user-attachments/assets/513861ff-72b8-4ae0-abfb-ff54f39882f8" />
